### PR TITLE
fix: download actual images from Reddit NSFW posts

### DIFF
--- a/src/background/reddit-api.ts
+++ b/src/background/reddit-api.ts
@@ -21,6 +21,8 @@ interface RedditGalleryItem {
 }
 
 interface RedditPostData {
+  url?: string;
+  url_overridden_by_dest?: string;
   secure_media?: {
     reddit_video?: RedditVideoData;
   };
@@ -105,6 +107,58 @@ function extensionFromMime(mime: string): string {
     "image/webp": "webp",
   };
   return map[mime] || "jpg";
+}
+
+export interface RedditImageInfo {
+  url: string;
+  extension: string;
+}
+
+export async function resolveRedditImageUrl(
+  postUrl: string
+): Promise<RedditImageInfo | null> {
+  const jsonUrl = postUrl.replace(/\/?$/, ".json");
+
+  try {
+    const res = await fetch(jsonUrl, {
+      headers: {
+        "User-Agent": "SocialMediaSaver/1.0",
+      },
+    });
+
+    if (!res.ok) {
+      console.warn(
+        `[Social Media Saver] Reddit JSON API returned ${res.status} for ${postUrl}`
+      );
+      return null;
+    }
+
+    const data: RedditListing[] = await res.json();
+
+    if (!Array.isArray(data) || data.length === 0) return null;
+
+    const postData = data[0]?.data?.children?.[0]?.data;
+    if (!postData) return null;
+
+    const imageUrl = postData.url_overridden_by_dest || postData.url;
+    if (!imageUrl || !imageUrl.includes("i.redd.it")) return null;
+
+    // Extract extension from URL
+    const extMatch = imageUrl.match(/\.(jpg|jpeg|png|webp|gif)(\?|$)/i);
+    const extension = extMatch
+      ? extMatch[1].toLowerCase() === "jpeg"
+        ? "jpg"
+        : extMatch[1].toLowerCase()
+      : "jpg";
+
+    return { url: imageUrl, extension };
+  } catch (err) {
+    console.error(
+      `[Social Media Saver] Reddit image JSON fetch error for ${postUrl}:`,
+      err
+    );
+    return null;
+  }
 }
 
 export async function resolveRedditGalleryUrls(

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -7,7 +7,7 @@ import type {
 } from "../shared/types";
 import { EXTENSION_NAME } from "../shared/constants";
 import { resolveVideoUrl } from "./api";
-import { resolveRedditVideoUrl, resolveRedditGalleryUrls } from "./reddit-api";
+import { resolveRedditVideoUrl, resolveRedditGalleryUrls, resolveRedditImageUrl } from "./reddit-api";
 
 // ---------------------------------------------------------------------------
 // Notification helper
@@ -368,6 +368,65 @@ chrome.runtime.onMessage.addListener(
         .catch((err) => {
           const msg = err instanceof Error ? err.message : String(err);
           console.error(`[${EXTENSION_NAME}] download-reddit-gallery error: ${msg}`);
+          notify("Error", msg);
+          sendResponse({ success: false, error: msg });
+        });
+      return true; // async sendResponse
+    }
+
+    if (message.type === "download-reddit-image") {
+      const { postUrl, subreddit, postId } = message;
+      console.log(`[${EXTENSION_NAME}] Received download-reddit-image request for ${postUrl}`);
+      notify("Starting download", `Resolving Reddit image...`);
+
+      resolveRedditImageUrl(postUrl)
+        .then((imageInfo) => {
+          if (!imageInfo) {
+            const errMsg = `Could not resolve image URL for Reddit post ${postId}`;
+            console.error(`[${EXTENSION_NAME}] ${errMsg}`);
+            notify("Error", errMsg);
+            chrome.action.setBadgeText({ text: "ERR" });
+            chrome.action.setBadgeBackgroundColor({ color: "#f4212e" });
+            setTimeout(() => {
+              if (activeDownloads.size === 0) {
+                chrome.action.setBadgeText({ text: "" });
+              }
+            }, 3000);
+            sendResponse({ success: false, error: errMsg });
+            return;
+          }
+
+          const filename = `r-${subreddit}_${postId}.${imageInfo.extension}`;
+
+          chrome.downloads.download(
+            {
+              url: imageInfo.url,
+              filename,
+              conflictAction: "uniquify",
+            },
+            (downloadId) => {
+              if (chrome.runtime.lastError) {
+                const err = chrome.runtime.lastError.message ?? "unknown error";
+                console.error(`[${EXTENSION_NAME}] Download API error: ${err}`);
+                notify("Error", err);
+                sendResponse({ success: false, error: err });
+                return;
+              }
+              if (downloadId !== undefined) {
+                trackDownload(downloadId, filename);
+                sendResponse({ success: true });
+              } else {
+                const errMsg = `Failed to start download for ${filename}`;
+                console.error(`[${EXTENSION_NAME}] ${errMsg}`);
+                notify("Error", errMsg);
+                sendResponse({ success: false, error: errMsg });
+              }
+            }
+          );
+        })
+        .catch((err) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[${EXTENSION_NAME}] download-reddit-image error: ${msg}`);
           notify("Error", msg);
           sendResponse({ success: false, error: msg });
         });

--- a/src/content-reddit/button.ts
+++ b/src/content-reddit/button.ts
@@ -10,6 +10,7 @@ import type {
   ImageInfo,
   RedditVideoDownloadRequest,
   RedditGalleryDownloadRequest,
+  RedditImageDownloadRequest,
 } from "../shared/types";
 
 const BUTTON_ATTR = "data-sms-save-btn";
@@ -100,37 +101,28 @@ function createSaveButton(post: HTMLElement): HTMLElement {
         chrome.runtime.sendMessage(videoMessage, onResponse);
       }
 
-      // Download images/gallery if present
-      if (hasGallery || hasImage) {
-        const imageUrls = extractImageUrls(post);
+      // Download gallery via API
+      if (hasGallery) {
+        pendingResponses++;
+        const galleryMessage: RedditGalleryDownloadRequest = {
+          type: "download-reddit-gallery",
+          postUrl,
+          subreddit: meta.subreddit,
+          postId: meta.postId,
+        };
+        chrome.runtime.sendMessage(galleryMessage, onResponse);
+      }
 
-        if (imageUrls.length > 0) {
-          // DOM extraction succeeded — use download-images
-          pendingResponses++;
-          const images: ImageInfo[] = imageUrls.map((url, index) => {
-            const ext = getImageExtension(url);
-            const n = imageUrls.length > 1 ? `_${index + 1}` : "";
-            return {
-              url,
-              filename: `r-${meta.subreddit}_${meta.postId}${n}.${ext}`,
-            };
-          });
-          const imageMessage: ImageDownloadRequest = {
-            type: "download-images",
-            images,
-          };
-          chrome.runtime.sendMessage(imageMessage, onResponse);
-        } else {
-          // DOM extraction failed — fall back to API-based gallery resolution
-          pendingResponses++;
-          const galleryMessage: RedditGalleryDownloadRequest = {
-            type: "download-reddit-gallery",
-            postUrl,
-            subreddit: meta.subreddit,
-            postId: meta.postId,
-          };
-          chrome.runtime.sendMessage(galleryMessage, onResponse);
-        }
+      // Download single image via API (handles NSFW blur correctly)
+      if (hasImage && !hasGallery) {
+        pendingResponses++;
+        const imageMessage: RedditImageDownloadRequest = {
+          type: "download-reddit-image",
+          postUrl,
+          subreddit: meta.subreddit,
+          postId: meta.postId,
+        };
+        chrome.runtime.sendMessage(imageMessage, onResponse);
       }
 
       // If only video was present and no image/gallery, pendingResponses is already set

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,10 +58,18 @@ export interface RedditGalleryDownloadRequest {
   postId: string;
 }
 
+export interface RedditImageDownloadRequest {
+  type: "download-reddit-image";
+  postUrl: string;
+  subreddit: string;
+  postId: string;
+}
+
 export type MessageRequest =
   | ImageDownloadRequest
   | VideoDownloadRequest
   | RedditVideoDownloadRequest
   | RedditGalleryDownloadRequest
+  | RedditImageDownloadRequest
   | GetDownloadStatusRequest
   | GetDownloadHistoryRequest;


### PR DESCRIPTION
## Summary
- Reddit NSFW posts show a blur overlay; the extension was downloading the blurred preview image instead of the actual content
- Added `resolveRedditImageUrl()` in `reddit-api.ts` that fetches the real image URL via Reddit's JSON API (same pattern as videos/galleries)
- Added `download-reddit-image` message type and service worker handler
- Updated Reddit content script to use API-based resolution for single-image posts instead of DOM extraction

## Test plan
- [ ] Load the unpacked extension from `dist/`
- [ ] Test download on a Reddit NSFW image post (e.g. a post with blur overlay) — should download the actual image
- [ ] Test download on a normal (non-NSFW) Reddit image post — should still work correctly
- [ ] Test that Reddit video and gallery downloads are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)