### PR TITLE
feat: Settings popup UI (quality, subfolder, theme)

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -3,7 +3,9 @@ import type {
   DownloadStatusResponse,
   DownloadHistoryEntry,
   DownloadHistoryResponse,
+  UserSettings,
 } from "../shared/types";
+import { DEFAULT_SETTINGS } from "../shared/types";
 import { EXTENSION_NAME } from "../shared/constants";
 import { resolveVideoUrl } from "./api";
 import {
@@ -14,6 +16,27 @@ import {
 } from "./reddit-api";
 import { resolveEmbedUrl } from "./embed-resolvers";
 import { DownloadQueue } from "./download-queue";
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+let currentSettings: UserSettings = DEFAULT_SETTINGS;
+chrome.storage.sync.get({ settings: DEFAULT_SETTINGS }, (res) => {
+  currentSettings = res.settings as UserSettings;
+});
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && changes.settings) {
+    currentSettings = changes.settings.newValue as UserSettings;
+  }
+});
+
+function applySubfolder(filename: string): string {
+  if (!currentSettings.subfolder || currentSettings.subfolder.trim() === "") {
+    return filename;
+  }
+  return `${currentSettings.subfolder.trim()}/${filename}`;
+}
 
 // ---------------------------------------------------------------------------
 // Notification helper
@@ -205,7 +228,7 @@ chrome.runtime.onMessage.addListener(
       );
       try {
         for (const image of message.images) {
-          queue.enqueue(image.url, image.filename, "twitter").then(() => {
+          queue.enqueue(image.url, applySubfolder(image.filename), "twitter").then(() => {
             refreshPolling();
           });
         }
@@ -247,7 +270,7 @@ chrome.runtime.onMessage.addListener(
             return;
           }
 
-          queue.enqueue(videoUrl, filename, "twitter").then(() => {
+          queue.enqueue(videoUrl, applySubfolder(filename), "twitter").then(() => {
             refreshPolling();
             sendResponse({ success: true });
           });
@@ -288,7 +311,7 @@ chrome.runtime.onMessage.addListener(
             return;
           }
 
-          queue.enqueue(videoUrl, filename, "reddit").then(() => {
+          queue.enqueue(videoUrl, applySubfolder(filename), "reddit").then(() => {
             refreshPolling();
             sendResponse({ success: true });
           });
@@ -331,7 +354,7 @@ chrome.runtime.onMessage.addListener(
           for (let i = 0; i < galleryImages.length; i++) {
             const img = galleryImages[i];
             const filename = `r-${subreddit}_${postId}_${i + 1}.${img.extension}`;
-            await queue.enqueue(img.url, filename, "reddit");
+            await queue.enqueue(img.url, applySubfolder(filename), "reddit");
           }
 
           refreshPolling();
@@ -373,7 +396,7 @@ chrome.runtime.onMessage.addListener(
           }
 
           const filename = `r-${subreddit}_${postId}.${imageInfo.extension}`;
-          queue.enqueue(imageInfo.url, filename, "reddit").then(() => {
+          queue.enqueue(imageInfo.url, applySubfolder(filename), "reddit").then(() => {
             refreshPolling();
             sendResponse({ success: true });
           });
@@ -414,7 +437,7 @@ chrome.runtime.onMessage.addListener(
             return;
           }
 
-          queue.enqueue(gifUrl, filename, "reddit").then(() => {
+          queue.enqueue(gifUrl, applySubfolder(filename), "reddit").then(() => {
             refreshPolling();
             sendResponse({ success: true });
           });
@@ -465,7 +488,7 @@ chrome.runtime.onMessage.addListener(
           }
 
           const filename = `r-${subreddit}_${postId}_${platform}.${result.extension}`;
-          queue.enqueue(result.url, filename, "reddit").then(() => {
+          queue.enqueue(result.url, applySubfolder(filename), "reddit").then(() => {
             refreshPolling();
             sendResponse({ success: true });
           });

--- a/src/content/media-detector.ts
+++ b/src/content/media-detector.ts
@@ -1,3 +1,15 @@
+import { DEFAULT_SETTINGS, DownloadQuality, UserSettings } from "../shared/types";
+
+let currentSettings = DEFAULT_SETTINGS;
+chrome.storage.sync.get({ settings: DEFAULT_SETTINGS }, (res) => {
+  currentSettings = res.settings as UserSettings;
+});
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && changes.settings) {
+    currentSettings = changes.settings.newValue as UserSettings;
+  }
+});
+
 const SELECTORS = {
   tweet: 'article[data-testid="tweet"]',
   tweetPhoto: '[data-testid="tweetPhoto"]',
@@ -84,7 +96,7 @@ export function extractImageUrls(tweet: HTMLElement): string[] {
     const img = container.querySelector<HTMLImageElement>("img[src]");
     if (!img) continue;
 
-    const url = toOriginalQuality(img.src);
+    const url = toQuality(img.src, currentSettings.quality);
     if (url) urls.push(url);
   }
 
@@ -95,11 +107,11 @@ export function extractImageUrls(tweet: HTMLElement): string[] {
  * Convert an X image URL to original quality by setting name=orig.
  * Returns the cleaned URL or null if it's not a recognized image URL.
  */
-function toOriginalQuality(src: string): string | null {
+function toQuality(src: string, quality: DownloadQuality): string | null {
   try {
     const url = new URL(src);
     if (!url.hostname.includes("twimg.com")) return null;
-    url.searchParams.set("name", "orig");
+    url.searchParams.set("name", quality);
     return url.toString();
   } catch {
     return null;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -291,3 +291,101 @@ body::-webkit-scrollbar-thumb {
 body::-webkit-scrollbar-thumb:hover {
   background: #3e4246;
 }
+
+/* Tabs */
+.tabs {
+  display: flex;
+  background-color: var(--bg-color);
+  border-bottom: 1px solid var(--border-color);
+  padding: 0 16px;
+}
+.tab-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 12px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+}
+.tab-btn:hover {
+  color: var(--text-color);
+}
+.tab-btn.active {
+  color: var(--accent-color);
+  border-bottom-color: var(--accent-color);
+}
+.tab-content {
+  display: none;
+}
+.tab-content.active {
+  display: block;
+}
+
+/* Settings Form */
+.settings-form {
+  padding: 16px;
+}
+.form-group {
+  margin-bottom: 16px;
+}
+.form-group label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 6px;
+  font-size: 14px;
+}
+.form-control {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.form-control:focus {
+  border-color: var(--accent-color);
+  outline: none;
+}
+.help-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.btn {
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+}
+.btn-primary {
+  background-color: var(--text-color);
+  color: var(--bg-color);
+}
+.btn-primary:hover {
+  opacity: 0.9;
+}
+.status-msg {
+  font-size: 12px;
+  margin-top: 8px;
+  color: var(--success-color);
+}
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.version-badge {
+  font-size: 10px;
+  background-color: var(--border-color);
+  padding: 2px 6px;
+  border-radius: 12px;
+  font-weight: normal;
+  vertical-align: middle;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -8,27 +8,68 @@
   </head>
   <body>
     <header class="header">
-      <svg class="header-icon" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-        <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
-      </svg>
-      <h1 class="header-title">X Media Saver</h1>
+      <div class="header-left">
+        <svg class="header-icon" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+        </svg>
+        <h1 class="header-title">Social Media Saver <span class="version-badge" id="version-badge">v0.4.0</span></h1>
+      </div>
     </header>
 
-    <section id="active-section" class="section" style="display: none">
-      <h2 class="section-title">Active Downloads</h2>
-      <div id="active-downloads"></div>
-    </section>
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="downloads">Downloads</button>
+      <button class="tab-btn" data-tab="settings">Settings</button>
+    </div>
 
-    <section id="history-section" class="section" style="display: none">
-      <h2 class="section-title">Recent Downloads</h2>
-      <div id="history-downloads"></div>
-    </section>
+    <div id="tab-downloads" class="tab-content active">
+      <section id="active-section" class="section" style="display: none">
+        <h2 class="section-title">Active Downloads</h2>
+        <div id="active-downloads"></div>
+      </section>
 
-    <div id="empty-state" class="empty-state">
-      <svg class="empty-icon" viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
-        <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
-      </svg>
-      <p>No downloads yet</p>
+      <section id="history-section" class="section" style="display: none">
+        <h2 class="section-title">Recent Downloads</h2>
+        <div id="history-downloads"></div>
+      </section>
+
+      <div id="empty-state" class="empty-state">
+        <svg class="empty-icon" viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
+          <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+        </svg>
+        <p>No downloads yet</p>
+      </div>
+    </div>
+
+    <div id="tab-settings" class="tab-content">
+      <div class="settings-form">
+        <div class="form-group">
+          <label for="setting-quality">Image Quality</label>
+          <select id="setting-quality" class="form-control">
+            <option value="orig">Original (Highest, uncompressed)</option>
+            <option value="large">Large (High quality)</option>
+            <option value="medium">Medium (Faster download)</option>
+          </select>
+          <div class="help-text">Does not affect video resolution (always maximum).</div>
+        </div>
+
+        <div class="form-group">
+          <label for="setting-subfolder">Download Subfolder</label>
+          <input type="text" id="setting-subfolder" class="form-control" placeholder="SocialMediaSaver" />
+          <div class="help-text">Files will be saved to <code>Downloads/&lt;subfolder&gt;/</code>. Leave blank to save directly to Downloads.</div>
+        </div>
+
+        <div class="form-group">
+          <label for="setting-theme">Theme</label>
+          <select id="setting-theme" class="form-control">
+            <option value="system">System Default</option>
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
+        </div>
+
+        <button id="save-settings-btn" class="btn btn-primary">Save Settings</button>
+        <div id="settings-status" class="status-msg"></div>
+      </div>
     </div>
 
     <script type="module" src="popup.ts"></script>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -9,13 +9,87 @@ import type {
   QueueRetryRequest,
   QueuePauseRequest,
   QueueResumeRequest,
+  UserSettings,
 } from "../shared/types";
+import { DEFAULT_SETTINGS } from "../shared/types";
 
 const activeSection = document.getElementById("active-section")!;
 const activeContainer = document.getElementById("active-downloads")!;
 const historySection = document.getElementById("history-section")!;
 const historyContainer = document.getElementById("history-downloads")!;
 const emptyState = document.getElementById("empty-state")!;
+
+// Tab Elements
+const tabBtns = document.querySelectorAll(".tab-btn");
+const tabContents = document.querySelectorAll(".tab-content");
+
+// Settings Elements
+const qualitySelect = document.getElementById("setting-quality") as HTMLSelectElement;
+const subfolderInput = document.getElementById("setting-subfolder") as HTMLInputElement;
+const themeSelect = document.getElementById("setting-theme") as HTMLSelectElement;
+const saveSettingsBtn = document.getElementById("save-settings-btn") as HTMLButtonElement;
+const settingsStatus = document.getElementById("settings-status")!;
+const versionBadge = document.getElementById("version-badge")!;
+
+// Set version dynamically
+versionBadge.textContent = "v" + chrome.runtime.getManifest().version;
+
+// ---------------------------------------------------------------------------
+// Tabs & Settings
+// ---------------------------------------------------------------------------
+
+tabBtns.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    // Remove active class
+    tabBtns.forEach((b) => b.classList.remove("active"));
+    tabContents.forEach((c) => c.classList.remove("active"));
+    
+    // Add active class
+    btn.classList.add("active");
+    const tabId = btn.getAttribute("data-tab");
+    document.getElementById(`tab-${tabId}`)!.classList.add("active");
+  });
+});
+
+function loadSettings() {
+  chrome.storage.sync.get({ settings: DEFAULT_SETTINGS }, (result) => {
+    const settings = result.settings as UserSettings;
+    qualitySelect.value = settings.quality;
+    subfolderInput.value = settings.subfolder;
+    themeSelect.value = settings.theme;
+    
+    applyTheme(settings.theme);
+  });
+}
+
+function applyTheme(theme: string) {
+  if (theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+    document.documentElement.style.setProperty("color-scheme", "dark");
+  } else {
+    document.documentElement.style.setProperty("color-scheme", "light");
+  }
+}
+
+saveSettingsBtn.addEventListener("click", () => {
+  const newSettings: UserSettings = {
+    quality: qualitySelect.value as UserSettings["quality"],
+    subfolder: subfolderInput.value.trim(),
+    theme: themeSelect.value as UserSettings["theme"],
+  };
+
+  chrome.storage.sync.set({ settings: newSettings }, () => {
+    settingsStatus.textContent = "Settings saved successfully!";
+    applyTheme(newSettings.theme);
+    
+    // Clear message after 3 seconds
+    setTimeout(() => {
+      settingsStatus.textContent = "";
+    }, 3000);
+  });
+});
+
+// Initialize settings
+loadSettings();
 
 // ---------------------------------------------------------------------------
 // Relative time formatting

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,3 +128,17 @@ export type MessageRequest =
   | QueueRetryRequest
   | QueuePauseRequest
   | QueueResumeRequest;
+
+export type DownloadQuality = "orig" | "large" | "medium";
+
+export interface UserSettings {
+  quality: DownloadQuality;
+  subfolder: string;
+  theme: "system" | "dark" | "light";
+}
+
+export const DEFAULT_SETTINGS: UserSettings = {
+  quality: "orig",
+  subfolder: "SocialMediaSaver",
+  theme: "system",
+};


### PR DESCRIPTION
Closes #9

## Features
- **Settings tab** added to the extension popup
- **Image Quality**: choose between `Original` (`name=orig`), `Large`, or `Medium`
- **Download Subfolder**: configurable folder path (defaults to `Downloads/SocialMediaSaver/`)
- **Theme**: System/Dark/Light selection
- **Persistent storage**: settings are saved to `chrome.storage.sync` and applied across devices

## Changes
- `src/popup/*`: Refactored to support tabbed navigation (Downloads vs Settings)
- `src/background/service-worker.ts`: Listens to settings changes and prepends the configured subfolder to all file downloads via `queue.enqueue()`
- `src/content/media-detector.ts`: Replaces hardcoded `name=orig` with dynamic quality based on current user settings