### PR TITLE
feat: Settings popup UI and filename customization

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -4,15 +4,58 @@ import type {
   DownloadStatusResponse,
   DownloadHistoryEntry,
   DownloadHistoryResponse,
+  AppSettings,
+  SaveSettingsRequest,
 } from "../shared/types";
-import { EXTENSION_NAME } from "../shared/constants";
+import { EXTENSION_NAME, SETTINGS_KEY, DEFAULT_SETTINGS } from "../shared/constants";
 import { resolveVideoUrl } from "./api";
+
+// ---------------------------------------------------------------------------
+// Settings persistence
+// ---------------------------------------------------------------------------
+
+async function getSettings(): Promise<AppSettings> {
+  const result = await chrome.storage.sync.get(SETTINGS_KEY);
+  const settings = result[SETTINGS_KEY] as Partial<AppSettings> | undefined;
+  return { ...DEFAULT_SETTINGS, ...settings };
+}
+
+async function saveSettings(settings: AppSettings): Promise<void> {
+  await chrome.storage.sync.set({ [SETTINGS_KEY]: settings });
+}
+
+// ---------------------------------------------------------------------------
+// Filename resolver
+// ---------------------------------------------------------------------------
+
+function formatFilename(
+  pattern: string,
+  folder: string,
+  vars: { username: string; tweetId: string; index?: number; date?: string; ext: string }
+): string {
+  let name = pattern
+    .replace(/{username}/g, vars.username)
+    .replace(/{tweetId}/g, vars.tweetId)
+    .replace(/{index}/g, vars.index !== undefined ? String(vars.index) : "")
+    .replace(/{date}/g, vars.date ?? new Date().toISOString().split("T")[0]);
+
+  // Clean up potential double dashes or empty parts if index is missing
+  name = name.replace(/-+/g, "-").replace(/^-|-$/g, "");
+
+  const subfolder = folder.trim();
+  const fullPath = subfolder ? `${subfolder}/${name}.${vars.ext}` : `${name}.${vars.ext}`;
+
+  return fullPath;
+}
 
 // ---------------------------------------------------------------------------
 // Notification helper
 // ---------------------------------------------------------------------------
 
-function notify(title: string, message: string): void {
+async function notify(title: string, message: string): Promise<void> {
+  const settings = await getSettings();
+  if (!settings.enableNotifications) return;
+
   chrome.notifications.create({
     type: "basic",
     iconUrl: chrome.runtime.getURL("icon.png"),
@@ -161,99 +204,129 @@ chrome.downloads.onChanged.addListener((delta) => {
 
 chrome.runtime.onMessage.addListener(
   (message: MessageRequest, _sender, sendResponse) => {
+    if (message.type === "get-settings") {
+      getSettings().then(sendResponse);
+      return true;
+    }
+
+    if (message.type === "save-settings") {
+      saveSettings(message.settings).then(() => sendResponse({ success: true }));
+      return true;
+    }
+
     if (message.type === "download-images") {
-      console.log(`[${EXTENSION_NAME}] Received download-images request`, message.images);
-      notify("Starting download", `Downloading ${message.images.length} image(s)...`);
-      try {
-        let success = false;
-        for (const image of message.images) {
-          chrome.downloads.download(
-            {
-              url: image.url,
-              filename: image.filename,
-              conflictAction: "uniquify",
-            },
-            (downloadId) => {
-              if (chrome.runtime.lastError) {
-                const err = chrome.runtime.lastError.message ?? "unknown error";
-                console.error(`[${EXTENSION_NAME}] Download API error: ${err}`);
-                notify("Error", err);
-                return;
+      const { images, tweetId, username } = message;
+      console.log(`[${EXTENSION_NAME}] Received download-images request`, images);
+
+      getSettings().then((settings) => {
+        notify("Starting download", `Downloading ${images.length} image(s)...`);
+
+        try {
+          images.forEach((image, index) => {
+            const ext = image.url.split(".").pop()?.split("?")[0]?.split(":")[0] ?? "jpg";
+            const filename = formatFilename(settings.filenamePattern, settings.downloadFolder, {
+              username,
+              tweetId,
+              index: images.length > 1 ? index + 1 : undefined,
+              ext,
+            });
+
+            chrome.downloads.download(
+              {
+                url: image.url,
+                filename,
+                conflictAction: "uniquify",
+              },
+              (downloadId) => {
+                if (chrome.runtime.lastError) {
+                  const err = chrome.runtime.lastError.message ?? "unknown error";
+                  console.error(`[${EXTENSION_NAME}] Download API error: ${err}`);
+                  notify("Error", err);
+                  return;
+                }
+                if (downloadId !== undefined) {
+                  trackDownload(downloadId, filename);
+                }
               }
-              if (downloadId !== undefined) {
-                trackDownload(downloadId, image.filename);
-              }
-            }
-          );
+            );
+          });
+          sendResponse({ success: true });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[${EXTENSION_NAME}] download-images error: ${msg}`);
+          notify("Error", msg);
+          sendResponse({ success: false, error: msg });
         }
-        sendResponse({ success: true });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[${EXTENSION_NAME}] download-images error: ${msg}`);
-        notify("Error", msg);
-        sendResponse({ success: false, error: msg });
-      }
-      return false; // synchronous sendResponse
+      });
+      return true;
     }
 
     if (message.type === "download-video") {
       const { tweetId, username } = message;
-      const filename = `@${username}_${tweetId}_video.mp4`;
       console.log(`[${EXTENSION_NAME}] Received download-video request for tweet ${tweetId}`);
-      notify("Starting download", `Resolving video for tweet ${tweetId}...`);
 
-      resolveVideoUrl(tweetId)
-        .then((videoUrl) => {
-          if (!videoUrl) {
-            const errMsg = `Could not resolve video URL for tweet ${tweetId}`;
-            console.error(`[${EXTENSION_NAME}] ${errMsg}`);
-            notify("Error", errMsg);
-            chrome.action.setBadgeText({ text: "ERR" });
-            chrome.action.setBadgeBackgroundColor({ color: "#f4212e" });
-            setTimeout(() => {
-              if (activeDownloads.size === 0) {
-                chrome.action.setBadgeText({ text: "" });
-              }
-            }, 3000);
-            sendResponse({ success: false, error: errMsg });
-            return;
-          }
+      getSettings().then((settings) => {
+        notify("Starting download", `Resolving video for tweet ${tweetId}...`);
 
-          chrome.downloads.download(
-            {
-              url: videoUrl,
-              filename,
-              conflictAction: "uniquify",
-            },
-            (downloadId) => {
-              if (chrome.runtime.lastError) {
-                const err = chrome.runtime.lastError.message ?? "unknown error";
-                console.error(`[${EXTENSION_NAME}] Download API error: ${err}`);
-                notify("Error", err);
-                sendResponse({ success: false, error: err });
-                return;
-              }
-              if (downloadId !== undefined) {
-                trackDownload(downloadId, filename);
-                sendResponse({ success: true });
-              } else {
-                const errMsg = `Failed to start download for ${filename}`;
-                console.error(`[${EXTENSION_NAME}] ${errMsg}`);
-                notify("Error", errMsg);
-                chrome.action.setBadgeText({ text: "ERR" });
-                chrome.action.setBadgeBackgroundColor({ color: "#f4212e" });
-                sendResponse({ success: false, error: errMsg });
-              }
+        resolveVideoUrl(tweetId)
+          .then((videoUrl) => {
+            if (!videoUrl) {
+              const errMsg = `Could not resolve video URL for tweet ${tweetId}`;
+              console.error(`[${EXTENSION_NAME}] ${errMsg}`);
+              notify("Error", errMsg);
+              chrome.action.setBadgeText({ text: "ERR" });
+              chrome.action.setBadgeBackgroundColor({ color: "#f4212e" });
+              setTimeout(() => {
+                if (activeDownloads.size === 0) {
+                  chrome.action.setBadgeText({ text: "" });
+                }
+              }, 3000);
+              sendResponse({ success: false, error: errMsg });
+              return;
             }
-          );
-        })
-        .catch((err) => {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(`[${EXTENSION_NAME}] download-video error: ${msg}`);
-          notify("Error", msg);
-          sendResponse({ success: false, error: msg });
-        });
-      return true; // async sendResponse
+
+            const filename = formatFilename(settings.filenamePattern, settings.downloadFolder, {
+              username,
+              tweetId,
+              ext: "mp4",
+            });
+
+            chrome.downloads.download(
+              {
+                url: videoUrl,
+                filename,
+                conflictAction: "uniquify",
+              },
+              (downloadId) => {
+                if (chrome.runtime.lastError) {
+                  const err = chrome.runtime.lastError.message ?? "unknown error";
+                  console.error(`[${EXTENSION_NAME}] Download API error: ${err}`);
+                  notify("Error", err);
+                  sendResponse({ success: false, error: err });
+                  return;
+                }
+                if (downloadId !== undefined) {
+                  trackDownload(downloadId, filename);
+                  sendResponse({ success: true });
+                } else {
+                  const errMsg = `Failed to start download for ${filename}`;
+                  console.error(`[${EXTENSION_NAME}] ${errMsg}`);
+                  notify("Error", errMsg);
+                  chrome.action.setBadgeText({ text: "ERR" });
+                  chrome.action.setBadgeBackgroundColor({ color: "#f4212e" });
+                  sendResponse({ success: false, error: errMsg });
+                }
+              }
+            );
+          })
+          .catch((err) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`[${EXTENSION_NAME}] download-video error: ${msg}`);
+            notify("Error", msg);
+            sendResponse({ success: false, error: msg });
+          });
+      });
+      return true;
     }
 
     if (message.type === "get-download-history") {

--- a/src/content/button.ts
+++ b/src/content/button.ts
@@ -96,18 +96,13 @@ function createSaveButton(tweet: HTMLElement, tweetId: string): HTMLElement {
         return;
       }
 
-      const images: ImageInfo[] = imageUrls.map((url, index) => {
-        const ext = getImageExtension(url);
-        const n = imageUrls.length > 1 ? `_${index + 1}` : "";
-        return {
-          url,
-          filename: `@${username}_${tweetId}${n}.${ext}`,
-        };
-      });
+      const images: ImageInfo[] = imageUrls.map((url) => ({ url }));
 
       const message: ImageDownloadRequest = {
         type: "download-images",
         images,
+        tweetId,
+        username,
       };
 
       console.log(`[${EXTENSION_NAME}] Sending download-images message`, message);

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -19,9 +19,33 @@ body {
 .header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
   padding: 14px 16px;
   border-bottom: 1px solid #2f3336;
+}
+
+.header-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  color: #71767b;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, color 0.2s;
+}
+
+.icon-btn:hover {
+  background: rgba(231, 233, 234, 0.1);
+  color: #1d9bf0;
 }
 
 .header-icon {
@@ -152,14 +176,111 @@ body {
   flex-shrink: 0;
 }
 
-/* Empty state */
-.empty-state {
+/* Settings View */
+.settings-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.settings-header .section-title {
+  margin: 0;
+}
+
+.settings-form {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 32px 16px;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e7e9ea;
+}
+
+.form-input {
+  background: #15202b;
+  border: 1px solid #2f3336;
+  border-radius: 4px;
+  color: #e7e9ea;
+  padding: 8px 10px;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus {
+  border-color: #1d9bf0;
+}
+
+.help-text {
+  font-size: 11px;
   color: #71767b;
+}
+
+.checkbox-group {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.checkbox-group label {
+  font-size: 13px;
+  color: #e7e9ea;
+  cursor: pointer;
+}
+
+.checkbox-group input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.primary-btn {
+  background: #1d9bf0;
+  color: white;
+  border: none;
+  border-radius: 20px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.primary-btn:hover {
+  background: #1a8cd8;
+}
+
+.primary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.save-status {
+  font-size: 11px;
+  color: #00ba7c;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.save-status.show {
+  opacity: 1;
 }
 
 .empty-icon {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -8,28 +8,72 @@
   </head>
   <body>
     <header class="header">
-      <svg class="header-icon" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-        <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
-      </svg>
-      <h1 class="header-title">X Media Saver</h1>
+      <div class="header-main">
+        <svg class="header-icon" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+        </svg>
+        <h1 class="header-title">X Media Saver</h1>
+      </div>
+      <button id="settings-btn" class="icon-btn" title="Settings">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+          <path d="M12 15.5A3.5 3.5 0 0 1 8.5 12 3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5 3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97 0-.33-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.08-.73-1.69-.98l-.37-2.65c-.04-.24-.25-.42-.5-.42h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1 0 .33.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.08.73 1.69.98l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1.01c.22.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66z"/>
+        </svg>
+      </button>
     </header>
 
-    <section id="active-section" class="section" style="display: none">
-      <h2 class="section-title">Active Downloads</h2>
-      <div id="active-downloads"></div>
-    </section>
+    <div id="main-view">
+      <section id="active-section" class="section" style="display: none">
+        <h2 class="section-title">Active Downloads</h2>
+        <div id="active-downloads"></div>
+      </section>
 
-    <section id="history-section" class="section" style="display: none">
-      <h2 class="section-title">Recent Downloads</h2>
-      <div id="history-downloads"></div>
-    </section>
+      <section id="history-section" class="section" style="display: none">
+        <h2 class="section-title">Recent Downloads</h2>
+        <div id="history-downloads"></div>
+      </section>
 
-    <div id="empty-state" class="empty-state">
-      <svg class="empty-icon" viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
-        <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
-      </svg>
-      <p>No downloads yet</p>
+      <div id="empty-state" class="empty-state">
+        <svg class="empty-icon" viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
+          <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+        </svg>
+        <p>No downloads yet</p>
+      </div>
     </div>
+
+    <section id="settings-view" class="section" style="display: none">
+      <div class="settings-header">
+        <button id="back-btn" class="icon-btn" title="Back">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+          </svg>
+        </button>
+        <h2 class="section-title">Settings</h2>
+      </div>
+
+      <div class="settings-form">
+        <div class="form-group">
+          <label class="form-label" for="download-folder">Download Subfolder</label>
+          <input class="form-input" type="text" id="download-folder" placeholder="e.g. X-Media" />
+          <p class="help-text">Folder inside Downloads</p>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label" for="filename-pattern">Filename Pattern</label>
+          <input class="form-input" type="text" id="filename-pattern" placeholder="{username}-{tweetId}-{index}" />
+          <p class="help-text">Tags: {username}, {tweetId}, {index}, {date}</p>
+        </div>
+
+        <div class="form-group checkbox-group">
+          <input type="checkbox" id="enable-notifications" />
+          <label for="enable-notifications">Show completion alerts</label>
+        </div>
+
+        <div class="settings-actions">
+          <button id="save-settings-btn" class="primary-btn">Save Settings</button>
+          <span id="save-status" class="save-status"></span>
+        </div>
+      </div>
+    </section>
 
     <script type="module" src="popup.ts"></script>
   </body>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -5,13 +5,27 @@ import type {
   DownloadHistoryResponse,
   DownloadProgressInfo,
   DownloadHistoryEntry,
+  AppSettings,
+  GetSettingsRequest,
+  SaveSettingsRequest,
 } from "../shared/types";
+
+const mainView = document.getElementById("main-view")!;
+const settingsView = document.getElementById("settings-view")!;
+const settingsBtn = document.getElementById("settings-btn")!;
+const backBtn = document.getElementById("back-btn")!;
 
 const activeSection = document.getElementById("active-section")!;
 const activeContainer = document.getElementById("active-downloads")!;
 const historySection = document.getElementById("history-section")!;
 const historyContainer = document.getElementById("history-downloads")!;
 const emptyState = document.getElementById("empty-state")!;
+
+const folderInput = document.getElementById("download-folder") as HTMLInputElement;
+const patternInput = document.getElementById("filename-pattern") as HTMLInputElement;
+const notifyCheckbox = document.getElementById("enable-notifications") as HTMLInputElement;
+const saveBtn = document.getElementById("save-settings-btn")!;
+const saveStatus = document.getElementById("save-status")!;
 
 // ---------------------------------------------------------------------------
 // Relative time formatting
@@ -128,6 +142,55 @@ function renderHistory(entries: DownloadHistoryEntry[]): void {
     historyContainer.appendChild(card);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Settings logic
+// ---------------------------------------------------------------------------
+
+function showSettings(): void {
+  mainView.style.display = "none";
+  settingsView.style.display = "block";
+  loadSettings();
+}
+
+function hideSettings(): void {
+  settingsView.style.display = "none";
+  mainView.style.display = "block";
+}
+
+function loadSettings(): void {
+  const msg: GetSettingsRequest = { type: "get-settings" };
+  chrome.runtime.sendMessage(msg, (settings: AppSettings) => {
+    if (chrome.runtime.lastError || !settings) return;
+    folderInput.value = settings.downloadFolder;
+    patternInput.value = settings.filenamePattern;
+    notifyCheckbox.checked = settings.enableNotifications;
+  });
+}
+
+function saveSettings(): void {
+  const settings: AppSettings = {
+    downloadFolder: folderInput.value.trim(),
+    filenamePattern: patternInput.value.trim(),
+    enableNotifications: notifyCheckbox.checked,
+  };
+
+  const msg: SaveSettingsRequest = { type: "save-settings", settings };
+  saveBtn.setAttribute("disabled", "true");
+
+  chrome.runtime.sendMessage(msg, () => {
+    saveBtn.removeAttribute("disabled");
+    saveStatus.textContent = "Saved!";
+    saveStatus.classList.add("show");
+    setTimeout(() => {
+      saveStatus.classList.remove("show");
+    }, 2000);
+  });
+}
+
+settingsBtn.addEventListener("click", showSettings);
+backBtn.addEventListener("click", hideSettings);
+saveBtn.addEventListener("click", saveSettings);
 
 // ---------------------------------------------------------------------------
 // Visibility logic

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,1 +1,11 @@
+import { AppSettings } from "./types";
+
 export const EXTENSION_NAME = "X Media Saver";
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  filenamePattern: "{username}-{tweetId}-{index}",
+  downloadFolder: "X-Media",
+  enableNotifications: true,
+};
+
+export const SETTINGS_KEY = "settings";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,11 +1,14 @@
 export interface ImageDownloadRequest {
   type: "download-images";
   images: ImageInfo[];
+  tweetId: string;
+  username: string;
 }
 
 export interface ImageInfo {
   url: string;
-  filename: string;
+  // filename is now optional, background script can generate it if missing
+  filename?: string;
 }
 
 export interface VideoDownloadRequest {
@@ -48,4 +51,21 @@ export type MessageRequest =
   | ImageDownloadRequest
   | VideoDownloadRequest
   | GetDownloadStatusRequest
-  | GetDownloadHistoryRequest;
+  | GetDownloadHistoryRequest
+  | GetSettingsRequest
+  | SaveSettingsRequest;
+
+export interface AppSettings {
+  filenamePattern: string;
+  downloadFolder: string;
+  enableNotifications: boolean;
+}
+
+export interface GetSettingsRequest {
+  type: "get-settings";
+}
+
+export interface SaveSettingsRequest {
+  type: "save-settings";
+  settings: AppSettings;
+}


### PR DESCRIPTION
This PR implements Issue #9:
- Added a Settings view to the popup.
- Configurable download subfolder and filename patterns (using tags like {username}, {tweetId}, etc.).
- Completion notifications toggle.
- Refactored download logic to use these settings.

Tagging <@1483906910632673380> for QA.